### PR TITLE
One-Dimensional Slicing

### DIFF
--- a/NumPyArrays.ipynb
+++ b/NumPyArrays.ipynb
@@ -147,6 +147,76 @@
     "# index data\n",
     "print(data[0,])"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[11 22 33 44 55]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# simple slicing\n",
+    "from numpy import array\n",
+    "# define array\n",
+    "data = array([11, 22, 33, 44, 55])\n",
+    "print(data[:])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[11]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# simple slicing\n",
+    "from numpy import array\n",
+    "# define array\n",
+    "data = array([11, 22, 33, 44, 55])\n",
+    "print(data[0:1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[44 55]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# simple slicing\n",
+    "from numpy import array\n",
+    "# define array\n",
+    "data = array([11, 22, 33, 44, 55])\n",
+    "print(data[-2:])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Slicing is specified using the colon operator ‘:’ with a ‘from‘ and ‘to‘ index before and after the column respectively. The slice extends from the ‘from’ index and ends one item before the ‘to’ index.
We can also use negative indexes in slices. For example, we can slice the last two items in the list by starting the slice at -2 (the second last item) and not specifying a ‘to’ index; that takes the slice to the end of the dimension.