### PR TITLE
2D Slicing: Split Input and Output Features

### DIFF
--- a/NumPyArrays.ipynb
+++ b/NumPyArrays.ipynb
@@ -213,6 +213,35 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[11 22]\n",
+      " [44 55]\n",
+      " [77 88]]\n",
+      "[33 66 99]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# split input and output\n",
+    "from numpy import array\n",
+    "# define array\n",
+    "data = array([[11, 22, 33],\n",
+    "\t\t[44, 55, 66],\n",
+    "\t\t[77, 88, 99]])\n",
+    "# separate data\n",
+    "X, y = data[:, :-1], data[:, -1]\n",
+    "print(X)\n",
+    "print(y)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
For the input features, we can select all rows and all columns except the last one by specifying ‘:’ for in the rows index, and :-1 in the columns index.
X = [:, :-1]
For the output column, we can select all rows again using ‘:’ and index just the last column by specifying the -1 index.
y = [:, -1]
Running the example prints the separated X and y elements. Note that X is a 2D array and y is a 1D array.