### PR TITLE
2D Slicing: Split Train and Test Rows

### DIFF
--- a/NumPyArrays.ipynb
+++ b/NumPyArrays.ipynb
@@ -242,6 +242,35 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[11 22 33]\n",
+      " [44 55 66]]\n",
+      "[[77 88 99]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# split train and test\n",
+    "from numpy import array\n",
+    "# define array\n",
+    "data = array([[11, 22, 33],\n",
+    "\t\t[44, 55, 66],\n",
+    "\t\t[77, 88, 99]])\n",
+    "# separate data\n",
+    "split = 2\n",
+    "train,test = data[:2,:],data[2:,:]\n",
+    "print(train)\n",
+    "print(test)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
This would involve slicing all columns by specifying ‘:’ in the second dimension index. The training dataset would be all rows from the beginning to the split point.
train = data[:split, :]
The test dataset would be all rows starting from the split point to the end of the dimension.
test = data[split:, :]