### PR TITLE
Reshape

### DIFF
--- a/NumPyArrays.ipynb
+++ b/NumPyArrays.ipynb
@@ -345,6 +345,61 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(5,)\n",
+      "(5, 1)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# reshape 1D array\n",
+    "from numpy import array\n",
+    "from numpy import reshape\n",
+    "# define array\n",
+    "data = array([11, 22, 33, 44, 55])\n",
+    "print(data.shape)\n",
+    "# reshape\n",
+    "data = data.reshape((data.shape[0], 1))\n",
+    "print(data.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(3, 2)\n",
+      "(3, 2, 1)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# reshape 2D array\n",
+    "from numpy import array\n",
+    "# list of data\n",
+    "data = [[11, 22],\n",
+    "\t\t[33, 44],\n",
+    "\t\t[55, 66]]\n",
+    "# array of data\n",
+    "data = array(data)\n",
+    "print(data.shape)\n",
+    "# reshape\n",
+    "data = data.reshape((data.shape[0], data.shape[1], 1))\n",
+    "print(data.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
NumPy provides the reshape() function on the NumPy array object that can be used to reshape the data.
The reshape() function takes a single argument that specifies the new shape of the array. In the case of reshaping a one-dimensional array into a two-dimensional array with one column, the tuple would be the shape of the array as the first dimension (data.shape[0]) and 1 for the second dimension.
data = data.reshape((data.shape[0], 1))
2D to 1D
We can use the sizes in the shape attribute on the array to specify the number of samples (rows) and columns (time steps) and fix the number of features at 1.
data.reshape((data.shape[0], data.shape[1], 1))